### PR TITLE
Handle EMFILE errors when requiring modules

### DIFF
--- a/lib/NormalModuleMixin.js
+++ b/lib/NormalModuleMixin.js
@@ -192,7 +192,7 @@ NormalModuleMixin.prototype.doBuild = function doBuild(options, moduleContext, r
 				} catch (e) {
 					// it is possible for node to choke on a require if the FD descriptor
 					// limit has been reached. give it a chance to recover.
-					if (e.code === 'EMFILE') {
+					if (e instanceof Error && e.code === 'EMFILE') {
 						if (typeof setImmediate === 'function') {
 							// node >= 0.9.0
 							return setImmediate(loadPitch.bind(this));


### PR DESCRIPTION
It is possible (at least on node 0.10.28) to get EMFILE errors thrown on webpack compilation. The errors originate inside of a `require` call.

Although one alternate solution is to increase the OS file limit, I don't believe that is a burden that should be pushed to the developer. On large projects, it is quite easy to hit the default OSX file descriptor limit.
