### PR TITLE
Support a predicate for `test` in `loaders`

### DIFF
--- a/lib/LoadersList.js
+++ b/lib/LoadersList.js
@@ -38,13 +38,17 @@ function asRegExp(test) {
 
 LoadersList.prototype.matchPart = function matchPart(str, test) {
 	if(!test) return true;
-	test = asRegExp(test);
-	if(Array.isArray(test)) {
-		return test.map(asRegExp).filter(function(regExp) {
-			return regExp.test(str);
-		}).length > 0;
+	if (typeof test === "function") {
+		return test(str);
 	} else {
-		return test.test(str);
+		test = asRegExp(test);
+		if(Array.isArray(test)) {
+			return test.map(asRegExp).filter(function(regExp) {
+				return regExp.test(str);
+			}).length > 0;
+		} else {
+			return test.test(str);
+		}
 	}
 };
 


### PR DESCRIPTION
Add support for passing in a predicate to `test` in `loaders` as a function of `str`.

Seems to have no perf impact on my local webpack usage, works like a charm.

Simple example of what this opens up:

```diff
--- webpack.config.js	2015-02-20 17:21:00.000000000 -0500
+++ changed.webpack.config.js	2015-02-20 17:21:08.000000000 -0500
@@ -11,7 +11,9 @@
   },
   module: {
     loaders: [{
-      test: /.+js$/,
+      test: function (str) {
+        return (str.indexOf('js') !== -1);
+      },
       loader: 'babel-loader'
     }, {
       test: /.scss$/,
```

Let me know if this works or why you wouldn't want this.