### PR TITLE
Accept functions as loader tests

### DIFF
--- a/lib/LoadersList.js
+++ b/lib/LoadersList.js
@@ -32,19 +32,23 @@ PART can be
 */
 
 function asRegExp(test) {
-	if(typeof test == "string") test = new RegExp("^"+test.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"));
-	return test;
+	return new RegExp("^"+test.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"));
 }
 
 LoadersList.prototype.matchPart = function matchPart(str, test) {
 	if(!test) return true;
-	test = asRegExp(test);
 	if(Array.isArray(test)) {
-		return test.map(asRegExp).filter(function(regExp) {
-			return regExp.test(str);
-		}).length > 0;
-	} else {
+		return test.filter(function(testPart) {
+			return this.matchPart(str, testPart);
+		}.bind(this)).length > 0;
+	} else if (test instanceof Function) {
+		return test(str);
+	} else if (typeof test === "string") {
+		return asRegExp(test).test(str);
+	} else if (test instanceof RegExp) {
 		return test.test(str);
+	} else {
+		throw new Error("Don't know how to handle loader test: " + test + " of type \"" + (typeof test) + "\"");
 	}
 };
 


### PR DESCRIPTION
Hi! I've been redoing our build process at Codecademy using webpack. Everyone is really excited to get their hands on it because it's going to speed up our development a lot, and it's much easier to work with than our current setup.

I ran into a limitation with the `loaders` option in the config, which I've addressed in this PR. The changes are backwards compatible.

### Changes made:

- handle loader tests which are functions that return true or false values. This allows for things that regexes can't do in JavaScript, like checking if a path ends in a substring
- make the Array option recursive, so it can contain a mix of test types
- handle the case where we get a test which is not a string, regex, or function
- clean up the `asRegExp` function

An example of how this can be useful: ignoring files with the extension `.es5.js` for the `babel-loader`.

```js
  module: {
    loaders: [
      {
        // treat everything in the webpack directory as es6, except blacklisted .es5.js files
        test: [/webpack.*/, function (str) {
          return !str.endsWith('es5.js');
        }], loader: 'babel-loader'
      }
    ]
  }
```

Thanks for working so hard on this project. As far as I can tell it's the best JS build system out there.