### PR TITLE
Always define options for OriginalSource.prototype.node

### DIFF
--- a/lib/OriginalSource.js
+++ b/lib/OriginalSource.js
@@ -55,6 +55,7 @@ OriginalSource.prototype.node = function(options) {
 	var value = this._value;
 	var name = this._name;
 	var lines = value.split("\n");
+	options = options || { columns: false };
 	var node = new SourceNode(null, null, null,
 		lines.map(function(line, idx) {
 			var pos = 0;


### PR DESCRIPTION
When options were undefined (don't really know why) you got a `TypeError: Cannot read property 'columns' of undefined` which killed the process. This seems to fix it locally for me at least.
