### PR TITLE
call the callback with err

### DIFF
--- a/lib/NormalModuleMixin.js
+++ b/lib/NormalModuleMixin.js
@@ -203,7 +203,7 @@ NormalModuleMixin.prototype.doBuild = function doBuild(options, moduleContext, r
 							return process.nextTick(loadPitch.bind(this));
 						}
 					}
-					throw e;
+					return callback(e)
 				}
 			}
 		} else if(typeof __webpack_require_loader__ === "function") {


### PR DESCRIPTION
@sokra I found this with a bad `npm install` with a missing module that a loader `require`'d. The error would print to the screen but the webpack process would exit with `0` after the compile stage.

Please let me know if this is the proper fix and what else I can do to get this merged upstream.