### PR TITLE
Add prepend method to ConcatSource

### DIFF
--- a/lib/ConcatSource.js
+++ b/lib/ConcatSource.js
@@ -19,6 +19,10 @@ ConcatSource.prototype.add = function(item) {
 	this.children.push(item);
 };
 
+ConcatSource.prototype.prepend = function(item) {
+	this.children.unshift(item);
+};
+
 ConcatSource.prototype.source = function() {
 	return this.children.map(function(item) {
 		return typeof item === "string" ? item : item.source();


### PR DESCRIPTION
I keep doing 

``` js
var source = new ConcatSource(sourceToPrepend, source);
```

This should be useful to just do,

``` js
source.prepend(sourceToPrepend);
```

Think, it might me useful ?
