### PR TITLE
Added messageText option for error reporting.

### DIFF
--- a/lib/ModuleBuildError.js
+++ b/lib/ModuleBuildError.js
@@ -3,6 +3,16 @@
 	Author Tobias Koppers @sokra
 */
 var loaderFlag = "WEBPACK_CORE_LOADER_EXECUTION";
+
+function extractMessage(err) {
+	if(typeof err.message === "string" && err.message) {
+		return err.message;
+	} else if(typeof err.messageText === "string" && err.messageText) {
+		return err.messageText;
+	}
+	return err;
+}
+
 function ModuleBuildError(module, err) {
 	Error.call(this);
 	Error.captureStackTrace(this, ModuleBuildError);
@@ -19,16 +29,10 @@ function ModuleBuildError(module, err) {
 				this.message += stack;
 			} else {
 				this.details = stack;
-				if(typeof err.message === "string" && err.message) {
-					this.message += err.message;
-				} else {
-					this.message += err;
-				}
+                		this.message += extractMessage(err);
 			}
-		} else if(typeof err.message === "string" && err.message) {
-			this.message += err.message;
 		} else {
-			this.message += err;
+			this.message += extractMessage(err);
 		}
 	}
 	this.module = module;


### PR DESCRIPTION
I had an issue with typescript compilation (awesome-typescript-loader for webpack) and all that was reported in the log was this:

```
ERROR in ./src/app/index.module.ts
Module build failed: [object Object]
```

when I debugged it, I noticed that it uses `messageText` instead of `message` for error message, so this is how I found out the real cause of the problem. The problem was not a typical TS compilation error, but due to this error message it took me a while to figure out the cause. Perhaps it's more the awesome-typescript-loader issue, but it's not up to me to decide.
Thanks.
Lukas
