### PR TITLE
Fix `LoadersList.js` accepts only arrays in `LoadersList.match()`

### DIFF
--- a/lib/LoadersList.js
+++ b/lib/LoadersList.js
@@ -77,8 +77,21 @@ LoadersList.prototype.match = function match(str) {
 			if(this.matchObject(str, element))
 				return getLoadersFromObject(element);
 		}
-	}, this).filter(Boolean).reduce(function(array, r) {
-		r.forEach(function(r) {
+	}, this).filter(Boolean).reduce(
+	/**
+	 * @param {Array} array
+	 * @param {Array|String} reduce
+	 * @return {Array}
+	 */
+	function(array, reduce) {
+		if (!Array.isArray(reduce)) {
+			if (typeof reduce === "string") {
+				reduce = [reduce];
+			} else {
+				reduce = [];
+			}
+		}
+		reduce.forEach(function(r) {
 			array.push(r);
 		});
 		return array;


### PR DESCRIPTION
Loaders list now accepts both arrays and strings. Example:

webpack-core/lib/LoadersList.js:81
    r.forEach(function(r) {
TypeError: r.forEach is not a function