### PR TITLE
Allow loaders list to contain objects w/ individual queries

### DIFF
--- a/lib/LoadersList.js
+++ b/lib/LoadersList.js
@@ -52,12 +52,22 @@ function asMatcher(test) {
 function getLoadersFromObject(element) {
 	if(element.query) {
 		if(!element.loader || element.loader.indexOf("!") >= 0) throw new Error("Cannot define 'query' and multiple loaders in loaders list");
-		if(typeof element.query === "string") return [element.loader + "?" + element.query];
-		return [element.loader + "?" + JSON.stringify(element.query)];
+		return [concatLoaderAndQuery(element.loader, element.query)];
 	}
 	if(element.loader) return element.loader.split("!");
-	if(element.loaders) return element.loaders;
+	if(element.loaders) {
+		return element.loaders.map(function(loader) {
+			if(typeof loader === "string") return loader;
+			if(!loader.query) return loader.loader;
+			return concatLoaderAndQuery(loader.loader, loader.query);
+		});
+	}
 	throw new Error("Element from loaders list should have one of the fields 'loader' or 'loaders'");
+}
+
+function concatLoaderAndQuery(loader, query) {
+	if(typeof query === "string") return loader + "?" + query;
+	return loader + "?" + JSON.stringify(query);
 }
 
 LoadersList.prototype.matchPart = function matchPart(str, test) {


### PR DESCRIPTION
It was bugging me that you can use the `query` object when using `loader`, while `loaders` requires the query to be defined as part of the string...so I figured I should stop quietly complaining to myself and fix it instead.

This pull request allows you to do the following:

```javascript
{
  ...
  module: {
    loaders: [{
      test: /\.scss$/,
      loaders: [
        { loader: 'style-loader' },
        { loader: 'css-loader', query: { modules: true } },
        { loader: 'sass-loader' }
      ]
    }]
  },
}
```

It's also possible to do a mix of objects and strings:

```javascript
{
  ...
  module: {
    loaders: [{
      test: /\.scss$/,
      loaders: [
        'style-loader', { loader: 'css-loader', query: { modules: true } }, 'sass-loader'
      ]
    }]
  },
}
```

This should satisfy the request in [this issue](https://github.com/webpack/core/issues/11).