### PR TITLE
Fixes Node.js v6 path must be a string error

### DIFF
--- a/lib/NormalModuleMixin.js
+++ b/lib/NormalModuleMixin.js
@@ -84,6 +84,9 @@ NormalModuleMixin.prototype.doBuild = function doBuild(options, moduleContext, r
 				var Module = require("module");
 				var m = new Module(filename, module);
 				m.paths = Module._nodeModulePaths(loaderContext.context);
+				if(!filename) {
+					filename = '';
+				}
 				m.filename = filename;
 				m._compile(code, filename);
 				return m.exports;


### PR DESCRIPTION
Otherwise Webpack 1 with Node 6 would get this error when trying to exec:

```
ERROR in ./my-project-file
Module build failed: TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.dirname (path.js:1324:5)
    at Module._compile (module.js:536:22)
    at Object.loaderContext.exec (/path/to/node_modules/webpack-core/lib/NormalModuleMixin.js:88:7)
```

This patch fixes it.