### PR TITLE
[feature/bug fix] Support for ES6 modules transpiled by babel >= 6

### DIFF
--- a/lib/NormalModuleMixin.js
+++ b/lib/NormalModuleMixin.js
@@ -211,6 +211,10 @@ NormalModuleMixin.prototype.doBuild = function doBuild(options, moduleContext, r
 		} else {
 			return callback(new Error("Cannot load loader, __webpack_require_loader__ not provided."));
 		}
+		// support for ES6 modules transpiled by babel >= 6
+		if (l.module && l.module.__esModule) {
+			l.module = l.module['default'];
+		}
 		if(typeof l.module !== "function")
 			return callback(new Error("Loader " + l.request + " didn't return a function"));
 		var pitchedLoaders = [];


### PR DESCRIPTION
## Motivation

When you use Babel 6 to transpile code, the exports varies a bit from regular CommonJS exports.
And because of that loaders written in ES6, transpiled by Babel 6 are not handled correctly in Webpack.

```
> webpack

Hash: 203cfe0179c71fd5b113
Version: webpack 1.13.0
Time: 903ms
        Asset     Size  Chunks             Chunk Names
./bin/main.js  1.95 kB       0  [emitted]  main
    + 3 hidden modules

ERROR in Loader c:\www\dll-prototype\dll-linker-example\node_modules\dll\lib\linker?dll-wrapper-example didn't return a function
 @ ./src/main.js 3:25-55
```

This is also related with: [#webpack/issues/2047](https://github.com/webpack/webpack/issues/2047)
## Pull request

I don't know if this is proper place for that, but I hope it's fine.
Would be great, if it's treated as patch, if merged.
