### PR TITLE
fix the error of loading loader on windows

### DIFF
--- a/lib/LoadersList.js
+++ b/lib/LoadersList.js
@@ -2,6 +2,8 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+var OS = require('os');
+
 function LoadersList(list) {
 	this.list = list || [];
 	this.list.forEach(function(element) {
@@ -19,6 +21,7 @@ function regExpAsMatcher(regExp) {
 
 function asMatcher(test) {
 	if(typeof test === "string") {
+		test = /windows/i.test(OS.type()) ? test.split('/').join('\\') : test;
 		return regExpAsMatcher(new RegExp("^"+test.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&")));
 	} else if(typeof test === "function") {
 		return test;


### PR DESCRIPTION
Writing {include: __dirname + '/web-src'} on windows will meet the problem: You may need an appropriate loader to handle this file type which causes that the babel loader doesn't work. It is a good way to unify the slash on windows.

The detail: [issue#19](https://github.com/creamidea/creamidea.github.com/issues/19)
