### PR TITLE
Bump source-map-list to 0.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "The core of webpack and enhanced-require.",
   "dependencies": {
     "source-map": "~0.4.1",
-    "source-list-map": "~0.1.0"
+    "source-list-map": "~0.1.7"
   },
   "licenses": [
     {


### PR DESCRIPTION
Per https://github.com/facebookincubator/create-react-app/pull/1101#issuecomment-264865954, we would like to make sure https://github.com/webpack/source-list-map/pull/3 ships to Webpack 1.x users without deleting `node_modules` and reinstalling.